### PR TITLE
[WIP] make .editorconfig easier to share the setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "test": "jest ./test",
     "test:es5": "jest ./test/es5.spec.js",
     "test:esnext": "jest ./test/esnext.spec.js",
-    "test:esnext-react": "jest ./test/esnext-react.spec.js"
+    "test:esnext-react": "jest ./test/esnext-react.spec.js",
+    "postinstall": "node postinstall.js"
   },
   "dependencies": {
     "babel-eslint": "^9.0.0",

--- a/postinstall.js
+++ b/postinstall.js
@@ -1,0 +1,9 @@
+var fs = require('fs');
+var path = require('path');
+
+var source = '.editorconfig';
+var target = '../../../.editorconfig';
+
+if (!fs.existsSync(target)) {
+  fs.createReadStream(source).pipe(fs.createWriteStream(target));
+}


### PR DESCRIPTION
### To do
- Auto provide .editorconfig file when the project not contain it. ✅
- If the project contain .editorconfig file, we will add rules that it does not.