### PR TITLE
Prettierをv1.15.1へ更新

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "eslint-plugin-dollar-sign": "^1.0.1",
     "eslint-plugin-prettier": "^3.0.0",
     "eslint-plugin-react": "^7.11.1",
-    "prettier": "^1.14.2"
+    "prettier": "^1.15.1"
   },
   "devDependencies": {
     "jest": "^23.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2757,9 +2757,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^1.14.2:
-  version "1.14.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.14.2.tgz#0ac1c6e1a90baa22a62925f41963c841983282f9"
+prettier@^1.15.1:
+  version "1.15.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.15.1.tgz#06c67106afb1b40e74b002353b2079cc7e0e67bf"
+  integrity sha512-4rgV2hyc/5Pk0XHH4VjJWHRgVjgRbpMfLQjREAhHBtyW1UvTFkjJEsueGYNYYZd9mn97K+1qv0EBwm11zoaSgA==
 
 pretty-format@^23.6.0:
   version "23.6.0"


### PR DESCRIPTION
@TakuyaAbe 
私の環境 (yarn: 1.12.1) で`yarn upgrade prettier --latest`をしたところ、`yarn.lock`ファイルに`integrity`という項目が追加されてしまいました。
このままマージして問題ないでしょうか？